### PR TITLE
Fixed jena version to 4.4.0

### DIFF
--- a/src/patch/jena.patch
+++ b/src/patch/jena.patch
@@ -49,16 +49,3 @@ index 63d5c3456c..9193bd9c84 100644
       */
      protected Set<String> generateAcceptedParams() {
          Set<String> x  = new HashSet<>();
-diff --git a/pom.xml b/pom.xml
-index d778e1f193..847b345033 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -54,7 +54,7 @@
-     <ver.junit>4.13.2</ver.junit>  
- 
-     <ver.slf4j>1.7.32</ver.slf4j>
--    <ver.log4j2>2.15.0</ver.log4j2>
-+    <ver.log4j2>2.17.1</ver.log4j2>
-     <ver.shade-plugin>3.2.4</ver.shade-plugin>
- 
-     <ver.jetty>10.0.7</ver.jetty>


### PR DESCRIPTION
Snapshot didn't exist anymore and therefore I fixed the
jena version to latest release.

Adapted the patch, because log4j was already updated.

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>