### PR TITLE
Changed regex for command parsing

### DIFF
--- a/src/main/java/net/catenax/semantics/triples/SparqlHelper.java
+++ b/src/main/java/net/catenax/semantics/triples/SparqlHelper.java
@@ -45,7 +45,7 @@ public class SparqlHelper {
     /**
      * a regular expression to extract the command of the query
      */
-    protected final static Pattern COMMAND_PATTERN=Pattern.compile("(?<Command>SELECT|INSERT|DELETE)[^;]*WHERE\\s*\\{[^;]*\\}");
+    protected final static Pattern COMMAND_PATTERN=Pattern.compile("(?<Command>SELECT|INSERT|DELETE)[^;]*WHERE\\s*\\{[\\s\\S]*\\}");
 
     /**
      * a regular expression to extract the (graph, service, logic) contexts


### PR DESCRIPTION
`SELECT` queries in SPARQL can contain `;` in `WHERE`
statements. Adopted the regex for command parsing.